### PR TITLE
Sim 33 ios changes, this now includes Android Sim 809.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5 @@
+{
+    "name": "cordova-plugin-onefile-error-logging",
+    "version": "1.0.1",
+    "lockfileVersion": 1
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cordova-plugin-onefile-error-logging",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "description": "Cordova Plugin Onefile Error Logging",
     "cordova": {
         "id": "cordova-plugin-onefile-error-logging",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cordova-plugin-onefile-error-logging",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "Cordova Plugin Onefile Error Logging",
     "cordova": {
         "id": "cordova-plugin-onefile-error-logging",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cordova-plugin-onefile-error-logging",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "description": "Cordova Plugin Onefile Error Logging",
     "cordova": {
         "id": "cordova-plugin-onefile-error-logging",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,6 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
 		id="cordova-plugin-onefile-error-logging"
-		version="1.0.1">
+		version="1.0.3">
 	<name>OneFile Error Logger</name>
 	<description>Cordova Plugin OneFile Error Logger</description>
 	<license>Onefile Limited</license>

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,6 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
 		id="cordova-plugin-onefile-error-logging"
-		version="1.0.3">
+		version="1.0.4">
 	<name>OneFile Error Logger</name>
 	<description>Cordova Plugin OneFile Error Logger</description>
 	<license>Onefile Limited</license>

--- a/src/android/OnefileErrorLogging.java
+++ b/src/android/OnefileErrorLogging.java
@@ -229,7 +229,7 @@ public class OnefileErrorLogging extends CordovaPlugin {
 		Date lastDate = null;
 		long seconds = Long.MAX_VALUE;
 		boolean sameError = false;
-		JSONObject lastError;
+		JSONObject lastError = null;
 		try {
 			lastError = getLastError();
 			if (lastError != null) {
@@ -240,34 +240,27 @@ public class OnefileErrorLogging extends CordovaPlugin {
 					System.out.println(lastDate);
 				} catch (ParseException e) {
 					e.printStackTrace();
-					return false;
+				}
+				if (lastDate != null) {
+					Date currentDate = new Date();
+					seconds = (currentDate.getTime() - lastDate.getTime()) / 1000;
+				}
+				JSONObject last = lastError.getJSONObject("error");
+				JSONObject current = config.getJSONObject("error");
+				String name1 = current.getString("name");
+				String name2 = last.getString("name");
+				String message1 = current.getString("message");
+				String message2 = last.getString("message");
+				String cause1 = current.getString("cause");
+				String cause2 = last.getString("cause");
+				if (name1.equals(name2) &&
+						message1.equals(message2) &&
+						cause1.equals(cause2)) {
+					sameError = true;
 				}
 			}
 		} catch (Exception e) {
 			e.printStackTrace();
-			return false;
-		}
-		if (lastDate != null) {
-			Date currentDate = new Date();
-			seconds = (currentDate.getTime() - lastDate.getTime()) / 1000;
-		}
-		try {
-			JSONObject last = lastError.getJSONObject("error");
-			JSONObject current = config.getJSONObject("error");
-			String name1 = current.getString("name");
-			String name2 = last.getString("name");
-			String message1 = current.getString("message");
-			String message2 = last.getString("message");
-			String cause1 = current.getString("cause");
-			String cause2 = last.getString("cause");
-			if(name1.equals(name2) &&
-					message1.equals(message2) &&
-					cause1.equals(cause2)) {
-				sameError = true;
-			}
-		} catch (Exception e) {
-			e.printStackTrace();
-			return false;
 		}
 		if (!sameError || (sameError && seconds > TIME_BETWEEN_DUPLICATE_ERRORS_IN_SECONDS)) {
 			if (saveErrorToDatabase(config)) {

--- a/src/ios/OnefileErrorLogging.h
+++ b/src/ios/OnefileErrorLogging.h
@@ -15,8 +15,12 @@ typedef NSUInteger CDVLogError;
 @interface OnefileErrorLogging : CDVPlugin
 {
     BOOL _inUse;
+    BOOL _allowSync;
 }
 @property BOOL inUse;
+@property BOOL allowSync;
 
 - (void)logError:(CDVInvokedUrlCommand*)command;
+- (NSDictionary *)getOldestError;
+- (void)scheduleUploads;
 @end

--- a/src/ios/OnefileErrorLogging.m
+++ b/src/ios/OnefileErrorLogging.m
@@ -49,18 +49,22 @@
     [dateFormatter setLocale: [NSLocale localeWithLocaleIdentifier: DATE_GLOBAL_LOCALE]];
     [dateFormatter setTimeZone: [NSTimeZone timeZoneWithName: @"UTC"]];
     NSDate *lastDate = [dateFormatter dateFromString: [lastErrorLogged objectForKey: @"dateLogged"]];
-    NSDate *currentDate = [NSDate date];
-    NSCalendar *cal = [[NSCalendar alloc] initWithCalendarIdentifier: NSCalendarIdentifierGregorian];
-    NSDateComponents *diff = [cal components: NSCalendarUnitSecond fromDate: lastDate toDate: currentDate options: 0];
-    if((int)[diff second] > TIME_BETWEEN_DUPLICATE_ERRORS_IN_SECONDS) {
-        NSDictionary *last = [lastErrorLogged objectForKey: @"error"];
-        NSDictionary *current =  [error objectForKey: @"error"];
-        if(!([[current objectForKey: @"name"] isEqual: [last objectForKey: @"name"]] &&
-           [[current objectForKey: @"message"] isEqual: [last objectForKey: @"message"]] &&
-           ![[current objectForKey: @"cause"] isEqual: [last objectForKey: @"cause"]]))
-        {
-            [database insertErrorWithDB: db config: error];
+    if (lastDate) {
+        NSDate *currentDate = [NSDate date];
+        NSCalendar *cal = [[NSCalendar alloc] initWithCalendarIdentifier: NSCalendarIdentifierGregorian];
+        NSDateComponents *diff = [cal components: NSCalendarUnitSecond fromDate: lastDate toDate: currentDate options: 0];
+        if((int)[diff second] > TIME_BETWEEN_DUPLICATE_ERRORS_IN_SECONDS) {
+            NSDictionary *last = [lastErrorLogged objectForKey: @"error"];
+            NSDictionary *current =  [error objectForKey: @"error"];
+            if(!([[current objectForKey: @"name"] isEqual: [last objectForKey: @"name"]] &&
+               [[current objectForKey: @"message"] isEqual: [last objectForKey: @"message"]] &&
+               ![[current objectForKey: @"cause"] isEqual: [last objectForKey: @"cause"]]))
+            {
+                [database insertErrorWithDB: db config: error];
+            }
         }
+    } else {
+        [database insertErrorWithDB: db config: error];
     }
     [database closeDatabase: db];
     self.allowSync = YES;

--- a/src/ios/OnefileErrorLogging.m
+++ b/src/ios/OnefileErrorLogging.m
@@ -3,6 +3,8 @@
 #import "sendrequest.h"
 
 #define MAX_NUMBER_OF_ERRORS 1000
+#define SYNC_n_EVERY_SECONDS (5.0 * 60.0)
+#define TIME_BETWEEN_DUPLICATE_ERRORS_IN_SECONDS (20.0)
 
 /************************************************************************************************************
  *      OnefileErrorLogging - Initialisation point of the plugin.
@@ -10,10 +12,12 @@
 @implementation OnefileErrorLogging
 
 @synthesize inUse = _inUse;
+@synthesize allowSync = _allowSync;
 
 - (void)pluginInitialize
 {
     self.inUse = NO;
+    self.allowSync = YES;
 }
 
 // ----------------------------------
@@ -23,45 +27,94 @@
 {
     NSString *callbackId = command.callbackId;
     NSDictionary *config = [command argumentAtIndex:0];
+    if ([config isKindOfClass: [NSNull class]]) {
+        config = [NSDictionary dictionary];
+    }
+    [self insertNewError:config];
+    
+    NSDictionary *response = @{
+            @"status": [NSNumber numberWithInteger: 200]
+    };
+    CDVPluginResult *result = [CDVPluginResult resultWithStatus: CDVCommandStatus_OK messageAsDictionary: response];
+    [self.commandDelegate sendPluginResult: result callbackId: callbackId];
+}
+
+- (void)insertNewError:(NSDictionary *)error
+{
+    sqlite3 *db = [database createOpenDatabase];
+    [database createTable:db];
+    NSDictionary *lastErrorLogged = [database getLastErrorFromDB:db];
+    NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+    [dateFormatter setDateFormat: DATABASE_DATE_TIME_FORMAT];
+    [dateFormatter setLocale: [NSLocale localeWithLocaleIdentifier: DATE_GLOBAL_LOCALE]];
+    [dateFormatter setTimeZone: [NSTimeZone timeZoneWithName: @"UTC"]];
+    NSDate *lastDate = [dateFormatter dateFromString: [lastErrorLogged objectForKey: @"dateLogged"]];
+    NSDate *currentDate = [NSDate date];
+    NSCalendar *cal = [[NSCalendar alloc] initWithCalendarIdentifier: NSCalendarIdentifierGregorian];
+    NSDateComponents *diff = [cal components: NSCalendarUnitSecond fromDate: lastDate toDate: currentDate options: 0];
+    if((int)[diff second] > TIME_BETWEEN_DUPLICATE_ERRORS_IN_SECONDS) {
+        NSDictionary *last = [lastErrorLogged objectForKey: @"error"];
+        NSDictionary *current =  [error objectForKey: @"error"];
+        if(!([[current objectForKey: @"name"] isEqual: [last objectForKey: @"name"]] &&
+           [[current objectForKey: @"message"] isEqual: [last objectForKey: @"message"]] &&
+           ![[current objectForKey: @"cause"] isEqual: [last objectForKey: @"cause"]]))
+        {
+            [database insertErrorWithDB: db config: error];
+        }
+    }
+    [database closeDatabase: db];
+    self.allowSync = YES;
+    [self scheduleUploads];
+}
+
+- (void)uploadErrors
+{
     NSDictionary *response;
     int processMaxErrors = MAX_NUMBER_OF_ERRORS;
     int status = 0;
-    if ([config isKindOfClass:[NSNull class]]) {
-        config = [NSDictionary dictionary];
-    }
+    NSDictionary *oldestError = [self getOldestError];
     do {
-        if([config count] > 0) {
-            int ID = [[config objectForKey:@"ID"] intValue];
-            response = [SendRequest makeRequest: config];
-            if([[response objectForKey:@"status"] isKindOfClass: [NSNumber class]])
-                status = [[response objectForKey:@"status"] intValue];
-            else
-                status = 0;
-            if(status == 200) {
-                sqlite3 *db = [database createOpenDatabase];
-                [database createTable:db];
-                if(ID > 0) {
-                    [database deleteErrorFromDB:db usingID: ID];
+        if([oldestError count] > 0) {
+            int ID = [[oldestError objectForKey: @"ID"] intValue];
+            if(ID > 0) {
+                response = [SendRequest makeRequest: oldestError];
+                if([[response objectForKey: @"status"] isKindOfClass: [NSNumber class]])
+                    status = [[response objectForKey: @"status"] intValue];
+                if(status == 200) {
+                    sqlite3 *db = [database createOpenDatabase];
+                    [database deleteErrorFromDB: db usingID: ID];
+                    [database closeDatabase: db];
+                    processMaxErrors--;
+                    if(processMaxErrors > 0) {
+                        oldestError = [self getOldestError];
+                    }
                 } else {
+                    processMaxErrors = 0;
+                    self.allowSync = NO;
                 }
-                processMaxErrors--;
-                if(processMaxErrors > 0)
-                    config = [database getErrorFromDB:db];
-                [database closeDatabase: db];
-            }
-            else
-            {
-                sqlite3 *db = [database createOpenDatabase];
-                [database createTable:db];
-                if(ID == 0) {
-                    [database insertErrorWithDB:db config:config];
-                }
-                [database closeDatabase: db];
             }
         }
-    } while(processMaxErrors > 0 && status > 0 && config && [config count] > 0);
+    } while(processMaxErrors > 0 && status > 0 && oldestError && [oldestError count] > 0);
+    [self scheduleUploads];
+}
 
-    CDVPluginResult *result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary: response];
-    [self.commandDelegate sendPluginResult:result callbackId:callbackId];
+- (void)scheduleUploads
+{
+    if(self.allowSync) {
+        self.allowSync = NO;
+        NSDictionary *oldestError = [self getOldestError];
+        int ID = [[oldestError objectForKey: @"ID"] intValue];
+        if (ID > 0) {
+            [NSTimer scheduledTimerWithTimeInterval: SYNC_n_EVERY_SECONDS target: self selector: @selector(uploadErrors) userInfo: nil repeats: NO];
+        }
+    }
+}
+
+- (NSDictionary *)getOldestError
+{
+    sqlite3 *db = [database createOpenDatabase];
+    NSDictionary *oldestError = [database getOldestErrorFromDB: db];
+    [database closeDatabase: db];
+    return oldestError;
 }
 @end

--- a/src/ios/database.h
+++ b/src/ios/database.h
@@ -30,4 +30,7 @@
 
 + (void)insertErrorWithDB:(sqlite3 *)db config:(NSDictionary *)config;
 + (NSDictionary *)getErrorFromDB: (sqlite3 *)db;
++ (NSDictionary *)getLastErrorFromDB: (sqlite3 *)db;
++ (NSDictionary *)getErrorFromDB: (sqlite3 *)db sql:(const char *) sql;
++ (NSDictionary *)getOldestErrorFromDB: (sqlite3 *)db;
 @end

--- a/src/ios/database.m
+++ b/src/ios/database.m
@@ -9,9 +9,7 @@
 #import "database.h"
 
 @implementation database
-/*
- *
- */
+
 + (sqlite3 *)createOpenDatabase
 {
     sqlite3 *db = NULL;
@@ -23,17 +21,11 @@
     return db;
 }
 
-/*
- *
- */
 + (void)closeDatabase:(sqlite3 *)db
 {
     sqlite3_close(db);
 }
 
-/*
- *
- */
 + (void)createTable:(sqlite3 *)db
 {
     sqlite3_stmt *sqlStmt;
@@ -54,9 +46,6 @@
     sqlite3_reset(sqlStmt);
 }
 
-/*
- *
- */
 + (void)insertErrorWithDB:(sqlite3 *)db config:(NSDictionary *)config
 {
     sqlite3_stmt *sqlStmt;
@@ -111,25 +100,30 @@
     }
 }
 
-/*
- *
- */
 + (NSString *)validateStringForUTF8: (char *)stringUTF
 {
     NSString *validString = ((stringUTF == nil) || (strcmp(stringUTF, "\0") == 0)) ? @"" : [NSString stringWithUTF8String: stringUTF];
     return validString;
 }
 
-/*
- *
- */
-+ (NSDictionary *)getErrorFromDB: (sqlite3 *)db
++ (NSDictionary *)getOldestErrorFromDB: (sqlite3 *)db
+{
+    const char *sql = "SELECT UserID, CurrentPlatform, CurrentPlatformVersion, Name, Message, Cause, StackTrace, ID, CurrentUsername, endpoint, DateLogged FROM Error ORDER BY DateLogged ASC LIMIT 1;";
+    return [database getErrorFromDB: db sql: sql];
+}
+
++ (NSDictionary *)getLastErrorFromDB: (sqlite3 *)db
+{
+    const char *sql = "SELECT UserID, CurrentPlatform, CurrentPlatformVersion, Name, Message, Cause, StackTrace, ID, CurrentUsername, endpoint, DateLogged FROM Error ORDER BY DateLogged DESC LIMIT 1;";
+    return [database getErrorFromDB: db sql: sql];
+}
+
++ (NSDictionary *)getErrorFromDB: (sqlite3 *)db sql:(const char *) sql
 {
     sqlite3_stmt *sqlStmt;
     NSDictionary *config = [[NSDictionary alloc] init];
     NSDictionary *header = [[NSDictionary alloc] init];
     NSDictionary *error = [[NSDictionary alloc] init];
-    const char *sql = "SELECT UserID, CurrentPlatform, CurrentPlatformVersion, Name, Message, Cause, StackTrace, ID, CurrentUsername, endpoint, DateLogged FROM Error LIMIT 1;";
     if((sqlite3_prepare_v2(db, sql, BUFFER_SIZE, &sqlStmt, NULL)) == SQLITE_OK)
     {
         while((sqlite3_step(sqlStmt)) == SQLITE_ROW)
@@ -172,9 +166,6 @@
     return config;
 }
 
-/*
- *
- */
 + (void)deleteErrorFromDB: (sqlite3 *)db usingID:(int)id
 {
     sqlite3_stmt *sqlStmt;
@@ -192,9 +183,6 @@
     sqlite3_finalize(sqlStmt);
 }
 
-/*
- *
- */
 + (void)deleteErrorTable:(sqlite3 *)db
 {
     sqlite3_stmt *sqlStmt;
@@ -211,9 +199,6 @@
     sqlite3_finalize(sqlStmt);
 }
 
-/*
- *
- */
 + (int)queryUserVersion:(sqlite3 *)db {
     static sqlite3_stmt *stmt_version;
     int databaseVersion = 0;


### PR DESCRIPTION
This is the iOS changes to insert errors which are not duplicates within a timeframe.
We now keep the errors in the database instead of sending up immediately to allow us to compare errors for a given timeframe. The errors will be synced in the background every 5 minutes, if the connection fails, otherwise up to a given number of errors are uploaded in that one sync.

Updated: 19/08/2020
This plugin now covers both iOS and Android.

Dependancy:

https://github.com/OneFileLtd/nomad-ionic/pull/305